### PR TITLE
Fix issue with consumer group timeouts

### DIFF
--- a/mltable/src/main/java/BUILD
+++ b/mltable/src/main/java/BUILD
@@ -25,6 +25,7 @@ java_library(
     deps = [
         "//mltable/src/main/resources:JavaMLTableProtobufs",
         artifact("org.slf4j:slf4j-api"),
+        artifact("org.apache.bookkeeper:bookkeeper-common"),
         artifact("org.apache.bookkeeper:bookkeeper-server"),
         artifact("org.apache.pulsar:managed-ledger-original"),
         artifact("com.google.guava:guava"),

--- a/mltable/src/main/java/io/streaml/mltable/MLTableBuilderImpl.java
+++ b/mltable/src/main/java/io/streaml/mltable/MLTableBuilderImpl.java
@@ -18,16 +18,25 @@ package io.streaml.mltable;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import org.apache.bookkeeper.common.util.OrderedExecutor;
+import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.client.api.BookKeeper;
-import org.apache.bookkeeper.mledger.ManagedLedger;
+
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
-import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
-import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenLedgerCallback;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerInitializeLedgerCallbackPromise;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MLTableBuilderImpl implements MLTableBuilder {
+    private final static Logger log = LoggerFactory.getLogger(MLTableBuilderImpl.class);
     private String tableName = null;
     private ExecutorService executor = null;
     private ManagedLedgerFactory mlFactory = null;
@@ -73,23 +82,45 @@ public class MLTableBuilderImpl implements MLTableBuilder {
 
         ManagedLedgerConfig mlConf = new ManagedLedgerConfig()
             .setEnsembleSize(2).setWriteQuorumSize(2).setAckQuorumSize(2);
+        OrderedExecutor orderedExecutor;
+        OrderedScheduler scheduledExecutor;
 
-        CompletableFuture<ManagedLedger> openPromise = new CompletableFuture<>();
-        mlFactory.asyncOpen(tableName, mlConf,
-                            new OpenLedgerCallback() {
-                                @Override
-                                public void openLedgerComplete(ManagedLedger ledger, Object ctx) {
-                                    openPromise.complete(ledger);
-                                }
-                                @Override
-                                public void openLedgerFailed(ManagedLedgerException exception, Object ctx) {
-                                    openPromise.completeExceptionally(exception);
-                                }
-                            }, null);
-        return openPromise.thenCompose(
-                (ledger) -> {
-                    MLTableImpl table = new MLTableImpl(tableName, config, ledger, bookkeeper, executor);
-                    return table.init().thenApply((ignore) -> table);
+        try {
+            Field orderedExecutorField = mlFactory.getClass().getDeclaredField("orderedExecutor");
+            orderedExecutorField.setAccessible(true);
+            orderedExecutor = (OrderedExecutor)orderedExecutorField.get(mlFactory);
+
+            Field scheduledExecutorField = mlFactory.getClass().getDeclaredField("scheduledExecutor");
+            scheduledExecutorField.setAccessible(true);
+            scheduledExecutor = (OrderedScheduler)scheduledExecutorField.get(mlFactory);
+        } catch (Exception e) {
+            CompletableFuture<MLTable> failPromise = new CompletableFuture<>();
+            failPromise.completeExceptionally(e);
+            return failPromise;
+        }
+
+        ManagedLedgerFactoryImpl factoryImpl = (ManagedLedgerFactoryImpl)mlFactory;
+        ManagedLedgerImpl ml = new ManagedLedgerImpl(factoryImpl,
+                factoryImpl.getBookKeeper(),
+                factoryImpl.getMetaStore(),
+                mlConf,
+                scheduledExecutor,
+                orderedExecutor,
+                tableName);
+        ManagedLedgerInitializeLedgerCallbackPromise initPromise = new ManagedLedgerInitializeLedgerCallbackPromise();
+        try {
+            Method initMethod = ml.getClass().getDeclaredMethod("initialize",
+                    ManagedLedgerInitializeLedgerCallbackPromise.parentClass(),
+                    Object.class);
+            initMethod.setAccessible(true);
+            initMethod.invoke(ml, initPromise, null);
+        } catch (Exception e) {
+            initPromise.completeExceptionally(e);
+        }
+        return initPromise.thenCompose(
+                (ignore0) -> {
+                    MLTableImpl table = new MLTableImpl(tableName, config, ml, bookkeeper, executor);
+                    return table.init().thenApply((ignore1) -> table);
                 });
     }
 }

--- a/mltable/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerInitializeLedgerCallbackPromise.java
+++ b/mltable/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerInitializeLedgerCallbackPromise.java
@@ -1,0 +1,22 @@
+package org.apache.bookkeeper.mledger.impl;
+
+import java.util.concurrent.CompletableFuture;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
+
+public class ManagedLedgerInitializeLedgerCallbackPromise
+    extends CompletableFuture<Void>
+    implements ManagedLedgerImpl.ManagedLedgerInitializeLedgerCallback {
+    @Override
+    public void initializeComplete() {
+        complete(null);
+    }
+
+    @Override
+    public void initializeFailed(ManagedLedgerException e) {
+        completeExceptionally(e);
+    }
+
+    public static Class<?> parentClass() {
+        return ManagedLedgerImpl.ManagedLedgerInitializeLedgerCallback.class;
+    }
+}

--- a/msggw/src/main/java/io/streaml/msggw/kafka/ConsumerGroupsImpl.java
+++ b/msggw/src/main/java/io/streaml/msggw/kafka/ConsumerGroupsImpl.java
@@ -997,7 +997,7 @@ public class ConsumerGroupsImpl implements ConsumerGroups {
         Map<String, Long> deadlines = memberData.entrySet()
             .stream().collect(Collectors.toMap(
                                       e -> e.getKey(),
-                                      e -> currentTickMs + e.getValue().getRebalanceTimeout()));
+                                      e -> currentTickMs + e.getValue().getSessionTimeout()/2));
         if (assignments.isEmpty()) {
             return new SyncingState(groupName,
                                     assignment.getGeneration(),


### PR DESCRIPTION
This PR fixes two issues.
- The primary issue when loading a mltable, we should ensure that we
  are not using a cached instance of the ManagedLedger. A cached
  instance will have the cursor set to the wrong entry to reads, so it
  will load junk from the log.
- When loading state from mltable, we should set the timeout for each
  member to be the half the session timeout. Previously, it was the
  rebalance timeout, which was too long. Using just the session
  timeout also doesn't work, as any saved members that don't join
  may have the same timeout as newly joining members, and the saved
  members may not rejoin, so the consumer group will never move into
  the syncing state.